### PR TITLE
Updated README.md, apollo.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,24 @@
 
 **Installation**
 
+Depending on your security level in your shell, the root password can be asked during the installation script to execute `sudo` commands during installation.
+
 `git clone https://github.com/caelumproject/Apollo && chmod -R 755 Apollo/`
 
-If you don't have Golang and/or go-caelum installed yet, run our installation script `./install-server.sh`.
+If you don't have Golang and/or go-caelum installed yet, run our installation script:
+`cd Apollo`
+`./install-server.sh`.
+Follow the prompts and accept/enter when asked. Once finished you might be asked to close/restart the terminal.
+On a successfull install you should have `go-caelum` as a directory alongside `Apollo`.
 
-Depending on your security level in your shell, the root password can be asked during the installation script to execute `sudo` commands during installation.
+Optional: create a directory to store the masternode/chain data:
+`mkdir YOUR_DATADIR`
 
 **Configuration**
 
-  - Set the folder where caelum should store the data in `DATADIR`.
+Edit `/Apollo/testnet.env` with the following:
+
+  - Set the folder where caelum should store the data in `DATADIR`. If you didn't make a directory earlier, leave as is.
   - Set your prefered public `PORT`.
   - Choose a unique `NAME` to get listed on the statistics page.
 
@@ -32,8 +41,6 @@ Run the apollo scipt by executing `./apollo.sh` along with one of the following 
 
  To know your coinbase account when setting up a masternode on https://master.testnet.caelumfoundation.com use the command `./apollo.sh list`.
 
-
-
  Check if you are displayed on our stats page https://stats.testnet.caelumfoundation.com/
 
  Send our developers a DM to receive some testnet tokens in order to activate and setup your masternode.
@@ -42,15 +49,43 @@ Run the apollo scipt by executing `./apollo.sh` along with one of the following 
 
 ---
 
+**Setting up a masternode with no initial masternode address**
+
+`./apollo.sh start` for the first time or `./apollo.sh new`
+
+It will ask you if you want to create a new coinbase account. Accepting (`y`) will then prompt you for a password.
+
+When asked to save the values/masternode to the configuration file say yes. (`y`)
+
+The password will be saved in `/Apollo/.pwd` and the address will be saved in `/Apollo/testnet.env`.
+
+Re-enter the password you created. This will then start the node and begin syncing.
+
+**Setting up a masternode with an existing masternode address (importing)**
+
+`caelum account import --password /path/to/Apollo/.pwd --datadir YOUR_DATADIR /path/to/PRIVATE_KEY`
+
+`YOUR_DATADIR` will be the path specified for `DATADIR` in `/Apollo/testnet.env`.
+
+`PRIVATE_KEY` needs to be a text file containing the address's private key. You can create a blank file with `nano` or `vi` and paste the private key, then save it. **Once the import is complete, delete this text file.**
+
+On success, `cd Apollo` then `./apollo.sh start` to start the node.
+
+---
+
 **Common issues**
+
+Note: You might need `sudo` permissions to run any commands below.
+
+On first install: `chmod: changing permissions of FILE/DIR denied`: rerun `chmod -R 755 Apollo` with `sudo` permissions.
 
 `permission denied` when running `.sh` files: First execute `chmod +x FILE_NAME` to grant permissions
 
-`error: Your local changes to the following files would be overwritten by merge:` Stash the local changes made by the `chmod` action by executing `git stash` first.
+When updating via `git pull`: `error: Your local changes to the following files would be overwritten by merge:` Stash the local changes made by the `chmod` action by executing `git stash` first.
 
 **Upgrading go-caelum**
 
-Whenever new updates are available, please run `./upgrade-caelum.sh`
+Whenever new updates are available, please run `./upgrade-caelum.sh`. 
 
 **Upgrade Apollo**
 
@@ -58,6 +93,4 @@ Whenever new updates are available, please run `./upgrade-caelum.sh`
 
 This will remove the repository and reinstall it completely.
 
-**Import a private key/account**
 
-`caelum account import --password .pwd --datadir YOUR_DATADIR PRIVATE_KEY`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Re-enter the password you created. This will then start the node and begin synci
 
 `PRIVATE_KEY` needs to be a text file containing the address's private key. You can create a blank file with `nano` or `vi` and paste the private key, then save it. **Once the import is complete, delete this text file.**
 
-On success, `cd Apollo` then `./apollo.sh start` to start the node.
+On success, `cd Apollo` then edit `testnet.env` and make `COINBASE` = your masternode address, minus the leading `0x`. Save, then `./apollo.sh start`.
 
 ---
 

--- a/apollo.sh
+++ b/apollo.sh
@@ -59,7 +59,7 @@ save_config() {
     then
       read -s -p "Coinbase unlocking password? "
       echo
-      sed -i "/COINBASE/s/=.*/=${get_coinbase}/" dev.env # Append coinbase
+      sed -i "/COINBASE/s/=.*/=${get_coinbase}/" testnet.env # Append coinbase
       echo $REPLY > .pwd # Save to .pwd file
     else
       echo Account creation aborted by user
@@ -97,7 +97,7 @@ start() {
   process_id=$!
 
   echo Caelum started with process id $process_id
-  sed -i "/PID/s/=.*/=${process_id}/" dev.env # Write process ID to config for logs
+  sed -i "/PID/s/=.*/=${process_id}/" testnet.env # Write process ID to config for logs
 }
 
 


### PR DESCRIPTION
Updated the README with detailed instructions on setting up masternodes.
Updated apollo.sh, replaced references to `dev.env` with `testnet.env`.